### PR TITLE
chore: upgrade Zinnia to v0.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: curl -L https://github.com/filecoin-station/zinnia/releases/download/v0.12.0/zinnia-linux-x64.tar.gz | tar -xz
+      - run: curl -L https://github.com/filecoin-station/zinnia/releases/download/v0.13.0/zinnia-linux-x64.tar.gz | tar -xz
       - uses: actions/setup-node@v3
       - run: npx standard
       - run: ./zinnia run test.js


### PR DESCRIPTION
Release notes:
https://github.com/filecoin-station/zinnia/releases/tag/v0.13.0
