### PR TITLE
feat: retrieval tasks based on IE rounds

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -85,7 +85,9 @@ export default class Spark {
       }
     })
     await assertOkResponse(res, 'Failed to submit retrieval')
-    console.log('Retrieval submitted')
+    const { measurementId } = await res.json()
+    console.log('Retrieval submitted (measurement id: %s)', measurementId)
+    return measurementId
   }
 
   async nextRetrieval () {
@@ -113,9 +115,9 @@ export default class Spark {
       console.error(err)
     }
 
-    await this.submitRetrieval(retrieval.id, { success, ...stats })
+    const measurementId = await this.submitRetrieval(retrieval.id, { success, ...stats })
     Zinnia.jobCompleted()
-    return retrieval.id
+    return measurementId
   }
 
   async run () {

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -72,26 +72,31 @@ export default class Spark {
     console.log(stats)
   }
 
-  async submitRetrieval (id, stats) {
-    console.log('Submitting retrieval...')
-    const res = await this.#fetch(`https://spark.fly.dev/retrievals/${id}`, {
-      method: 'PATCH',
-      body: JSON.stringify({
-        ...stats,
-        walletAddress: Zinnia.walletAddress
-      }),
+  async submitMeasurement (task, stats) {
+    console.log('Submitting measurement...')
+    const payload = {
+      sparkVersion: SPARK_VERSION,
+      zinniaVersion: Zinnia.versions.zinnia,
+      ...task,
+      ...stats,
+      walletAddress: Zinnia.walletAddress
+    }
+    console.log('%o', payload)
+    const res = await this.#fetch('https://spark.fly.dev/measurements', {
+      method: 'POST',
+      body: JSON.stringify(payload),
       headers: {
         'Content-Type': 'application/json'
       }
     })
-    await assertOkResponse(res, 'Failed to submit retrieval')
-    const { measurementId } = await res.json()
-    console.log('Retrieval submitted (measurement id: %s)', measurementId)
-    return measurementId
+    await assertOkResponse(res, 'Failed to submit measurement')
+    const { id } = await res.json()
+    console.log('Measurement submitted (id: %s)', id)
+    return id
   }
 
   async nextRetrieval () {
-    const retrieval = await this.getRetrieval()
+    const { id: retrievalId, ...retrieval } = await this.getRetrieval()
 
     let success = false
     const stats = {
@@ -115,7 +120,7 @@ export default class Spark {
       console.error(err)
     }
 
-    const measurementId = await this.submitRetrieval(retrieval.id, { success, ...stats })
+    const measurementId = await this.submitMeasurement(retrieval, { success, ...stats })
     Zinnia.jobCompleted()
     return measurementId
   }

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -15,16 +15,16 @@ export default class Spark {
 
   async getRetrieval () {
     console.log('Getting retrieval...')
-    const res = await this.#fetch('https://spark.fly.dev/retrievals', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        sparkVersion: SPARK_VERSION,
-        zinniaVersion: Zinnia.versions.zinnia
-      })
+    const res = await this.#fetch('https://spark.fly.dev/rounds/current', {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
     })
-    await assertOkResponse(res, 'Failed to create a new retrieval')
-    const retrieval = await res.json()
+    await assertOkResponse(res, 'Failed to fetch the current SPARK round')
+    const { retrievalTasks, ...round } = await res.json()
+    console.log('Current SPARK round:', round)
+    console.log('  %s retrieval tasks', retrievalTasks.length)
+
+    const retrieval = retrievalTasks[Math.floor(Math.random() * retrievalTasks.length)]
     console.log({ retrieval })
     return retrieval
   }

--- a/test/integration.js
+++ b/test/integration.js
@@ -4,8 +4,8 @@ import { assert } from 'zinnia:assert'
 
 test('integration', async () => {
   const spark = new Spark()
-  const id = await spark.nextRetrieval()
-  const res = await fetch(`https://spark.fly.dev/retrievals/${id}`)
+  const measurementId = await spark.nextRetrieval()
+  const res = await fetch(`https://spark.fly.dev/measurements/${measurementId}`)
   assert(res.ok)
   const retrieval = await res.json()
   assert(retrieval.startAt)

--- a/test/spark.js
+++ b/test/spark.js
@@ -2,11 +2,25 @@
 
 import Spark from '../lib/spark.js'
 import { test } from 'zinnia:test'
-import { assertInstanceOf, assertEquals } from 'zinnia:assert'
+import { assertInstanceOf, assertEquals, assertArrayIncludes } from 'zinnia:assert'
 import { SPARK_VERSION } from '../lib/constants.js'
 
 test('getRetrieval', async () => {
-  const retrieval = { retrieval: 'retrieval' }
+  const round = {
+    roundId: '123',
+    retrievalTasks: [
+      {
+        cid: 'bafkreidysaugf7iuvemebpzwxxas5rctbyiryykagup2ygkojmx7ag64gy',
+        providerAddress: '/ip4/38.70.220.96/tcp/10201/p2p/12D3KooWSekjEqdSeHXkpQraVY2STL885svgmh6r2zEFHQKeJ3KD',
+        protocol: 'graphsync'
+      },
+      {
+        cid: 'QmUMpWycKJ7GUDJp9GBRX4qWUFUePUmHzri9Tm1CQHEzbJ',
+        providerAddress: '/dns4/elastic.dag.house/tcp/443/wss/p2p/QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC',
+        protocol: 'bitswap'
+      }
+    ]
+  }
   const requests = []
   const fetch = async (url, opts) => {
     requests.push({ url, opts })
@@ -14,21 +28,18 @@ test('getRetrieval', async () => {
       status: 200,
       ok: true,
       async json () {
-        return retrieval
+        return round
       }
     }
   }
   const spark = new Spark({ fetch })
-  assertEquals(await spark.getRetrieval(), retrieval)
+  const retrieval = await spark.getRetrieval()
+  assertArrayIncludes(round.retrievalTasks, [retrieval])
   assertEquals(requests, [{
-    url: 'https://spark.fly.dev/retrievals',
+    url: 'https://spark.fly.dev/rounds/current',
     opts: {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        sparkVersion: SPARK_VERSION,
-        zinniaVersion: Zinnia.versions.zinnia
-      })
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
     }
   }])
 })

--- a/test/spark.js
+++ b/test/spark.js
@@ -70,16 +70,19 @@ test('submitRetrieval', async () => {
   const requests = []
   const fetch = async (url, opts) => {
     requests.push({ url, opts })
-    return { status: 200, ok: true }
+    return { status: 200, ok: true, async json () { return { id: 123 } } }
   }
   const spark = new Spark({ fetch })
-  await spark.submitRetrieval(0, { success: true })
+  await spark.submitMeasurement({ cid: 'bafytest' }, { success: true })
   assertEquals(requests, [
     {
-      url: 'https://spark.fly.dev/retrievals/0',
+      url: 'https://spark.fly.dev/measurements',
       opts: {
-        method: 'PATCH',
+        method: 'POST',
         body: JSON.stringify({
+          sparkVersion: SPARK_VERSION,
+          zinniaVersion: Zinnia.versions.zinnia,
+          cid: 'bafytest',
           success: true,
           walletAddress: Zinnia.walletAddress
         }),


### PR DESCRIPTION
1. fix tests to use the new `GET /measurements/:id` API
2. submit retrieval results via `POST /measurements` API
3. choose retrievals using `GET /rounds/current`

See https://github.com/filecoin-station/spark/issues/13
