### PR TITLE
feat: rename walletAddress to participantAddress

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -79,7 +79,7 @@ export default class Spark {
       zinniaVersion: Zinnia.versions.zinnia,
       ...task,
       ...stats,
-      walletAddress: Zinnia.walletAddress
+      participantAddress: Zinnia.walletAddress
     }
     console.log('%o', payload)
     const res = await this.#fetch('https://spark.fly.dev/measurements', {

--- a/test/spark.js
+++ b/test/spark.js
@@ -95,7 +95,7 @@ test('submitRetrieval', async () => {
           zinniaVersion: Zinnia.versions.zinnia,
           cid: 'bafytest',
           success: true,
-          walletAddress: Zinnia.walletAddress
+          participantAddress: Zinnia.walletAddress
         }),
         headers: { 'Content-Type': 'application/json' }
       }


### PR DESCRIPTION
Rename the measurement field to match the changes we are making on the spark-api and spark-evaluate sides.

The tests will keep failing until we deploy https://github.com/filecoin-station/spark-api/pull/97
