### PR TITLE
Change success definition

### DIFF
--- a/lib/activity-state.js
+++ b/lib/activity-state.js
@@ -1,26 +1,26 @@
 /* global Zinnia */
 
-// Create activity events when we go online or offline
+// Create activity events when we become healthy or produce errors
 export class ActivityState {
-  #ok = null
+  #healthy = null
 
   onOutdatedClient () {
     this.onError('SPARK is outdated. Please upgrade Filecoin Station to the latest version.')
   }
 
   onError (msg) {
-    if (this.#ok === null || this.#ok) {
-      this.#ok = false
+    if (this.#healthy === null || this.#healthy) {
+      this.#healthy = false
       Zinnia.activity.error(msg ?? 'SPARK failed reporting retrieval')
     }
   }
 
-  onSuccess () {
-    if (this.#ok === null) {
-      this.#ok = true
+  onHealthy () {
+    if (this.#healthy === null) {
+      this.#healthy = true
       Zinnia.activity.info('SPARK started reporting retrievals')
-    } else if (!this.#ok) {
-      this.#ok = true
+    } else if (!this.#healthy) {
+      this.#healthy = true
       Zinnia.activity.info('SPARK retrieval reporting resumed')
     }
   }

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -159,7 +159,7 @@ export default class Spark {
     while (true) {
       try {
         await this.nextRetrieval()
-        this.#activity.onSuccess()
+        this.#activity.onHealthy()
       } catch (err) {
         if (err.statusCode === 400 && err.serverMessage === 'OUTDATED CLIENT') {
           this.#activity.onOutdatedClient()

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -126,7 +126,6 @@ export default class Spark {
   async nextRetrieval () {
     const { id: retrievalId, ...retrieval } = await this.getRetrieval()
 
-    let success = false
     const stats = {
       timeout: false,
       startAt: new Date(),
@@ -144,13 +143,12 @@ export default class Spark {
     const url = `ipfs://${retrieval.cid}?${searchParams.toString()}`
     try {
       await this.fetchCAR(url, stats)
-      success = true
     } catch (err) {
       console.error(`Failed to fetch ${url}`)
       console.error(err)
     }
 
-    const measurementId = await this.submitMeasurement(retrieval, { success, ...stats })
+    const measurementId = await this.submitMeasurement(retrieval, { ...stats })
     Zinnia.jobCompleted()
     return measurementId
   }

--- a/test/spark.js
+++ b/test/spark.js
@@ -117,7 +117,7 @@ test('submitRetrieval', async () => {
     return { status: 200, ok: true, async json () { return { id: 123 } } }
   }
   const spark = new Spark({ fetch })
-  await spark.submitMeasurement({ cid: 'bafytest' }, { success: true })
+  await spark.submitMeasurement({ cid: 'bafytest' }, {})
   assertEquals(requests, [
     {
       url: 'https://spark.fly.dev/measurements',
@@ -127,7 +127,6 @@ test('submitRetrieval', async () => {
           sparkVersion: SPARK_VERSION,
           zinniaVersion: Zinnia.versions.zinnia,
           cid: 'bafytest',
-          success: true,
           participantAddress: Zinnia.walletAddress
         }),
         headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
Ref https://github.com/filecoin-station/spark/pull/28#discussion_r1343896336

@bajtos I've removed `.success`, since the presence of `.carChecksum` marks a successful retrieval