### PR TITLE
fix: report healthy state earlier

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -21,6 +21,7 @@ export default class Spark {
       headers: { 'Content-Type': 'application/json' }
     })
     await assertOkResponse(res, 'Failed to fetch the current SPARK round')
+    this.#activity.onHealthy()
     const { retrievalTasks, ...round } = await res.json()
     console.log('Current SPARK round:', round)
     console.log('  %s retrieval tasks', retrievalTasks.length)


### PR DESCRIPTION
Report the healthy state as soon as we can fetch round details from spark-api. This way Station Desktop becomes "online" faster on startup or after network disconnect.
