### PR TITLE
feat: fetch only the root block

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -140,6 +140,9 @@ export default class Spark {
       statusCode: null
     }
     const searchParams = new URLSearchParams({
+      // See https://github.com/filecoin-project/lassie/blob/main/docs/HTTP_SPEC.md#dag-scope-request-query-parameter
+      // Only the root block at the end of the path is returned after blocks required to verify the specified path segments.
+      'dag-scope': 'block',
       protocols: retrieval.protocol,
       providers: retrieval.providerAddress
     })

--- a/test/spark.js
+++ b/test/spark.js
@@ -3,7 +3,7 @@
 import Spark from '../lib/spark.js'
 import { test } from 'zinnia:test'
 import { assertInstanceOf, assertEquals, assertArrayIncludes } from 'zinnia:assert'
-import { SPARK_VERSION, MAX_CAR_SIZE } from '../lib/constants.js'
+import { SPARK_VERSION } from '../lib/constants.js'
 
 test('getRetrieval', async () => {
   const round = {

--- a/test/spark.js
+++ b/test/spark.js
@@ -82,6 +82,7 @@ test('fetchCAR', async () => {
   assertEquals(requests, [{ url: URL }])
 })
 
+/* Disabled as long as we are fetching the top-level block only
 test('fetchCAR exceeding MAX_CAR_SIZE', async () => {
   const URL = 'url'
   const fetch = async url => {
@@ -110,6 +111,7 @@ test('fetchCAR exceeding MAX_CAR_SIZE', async () => {
   assertEquals(stats.carChecksum, null)
   assertEquals(stats.statusCode, 200)
 })
+*/
 
 test('submitRetrieval', async () => {
   const requests = []


### PR DESCRIPTION
SPARK is about retrieval testing not load testing.

Currently, more than 90% of retrievals fail on timeout or server errors. There is little value in checking whether we can download the entire CAR file; it's more important to know whether SPs are advertising FIL+ deals to IPNI and accepting HTTP-based retrieval requests.

SPARK is also currently unable to fetch and verify CAR files larger than 200MB, which further reduces the value of fetching full CAR files.

Let's fetch the root block for the time being.
- This should significantly reduce the load on "good" SPs.
- It provides enough data to help "bad" SPs fix their setup.

/cc @rvagg @hannahhoward @willscott @gruns do you have any thoughts on this?

See also:
- https://github.com/filecoin-station/roadmap/issues/52
