### PR TITLE
ci: add publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: curl -L https://api.github.com/repos/${{ github.repository }}/tarball/${{ github.sha }} > source.tar.gz
+      - run: curl -L ${{ github.event.release.tarball_url }} > source.tar.gz
       - uses: filecoin-station/publish-zinnia-module-action@v0
         with:
           source: source.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -L https://api.github.com/repos/${{ github.repository }}/tarball/${{ github.sha }} > source.tar.gz
+      - uses: filecoin-station/publish-zinnia-module-action@v0
+        with:
+          source: source.tar.gz
+          w3up-private-key: ${{ secrets.W3UP_PRIVATE_KEY }}
+          w3up-proof: ${{ secrets.W3UP_PROOF }}
+          w3name-private-key: ${{ secrets.W3NAME_PRIVATE_KEY }}
+          w3name-revision: ${{ secrets.W3NAME_REVISION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [published]
+    types: [released]
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This automatically publishes the module source ip IPFS/IPNI, when a release has been created. Then, Station Core's auto updater will be able fetch it.

All secrets have been configured on the repo, and stored in 1password with additional context.

Caveat: If we create a new stable release, which is however not the "latest" version, the action will publish it and overwrite the current IPNI pointer anyways. I see this as low risk atm. Do you have any ideas how we could circumvent that?