### PR TITLE
fix: update approx. round length to 20 minutes

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,3 @@
 export const SPARK_VERSION = '1.7.1'
 export const MAX_CAR_SIZE = 200 * 1024 * 1024 // 200 MB
-export const APPROX_ROUND_LENGTH_IN_MS = 60 * 60_000 // 1 hour
+export const APPROX_ROUND_LENGTH_IN_MS = 20 * 60_000 // 20 minutes


### PR DESCRIPTION
This is a follow-up for the change we made recently that reduced Spark Meridian round length to 20 minutes:
- https://github.com/filecoin-station/spark/issues/50

It would be nice if Spark could read this value from the Meridian state in the future, but considering how infrequently we are changing this value, the current manual process is IMO good enough for now.

Note: once we deploy this change, the Spark network will perform 3x more retrievals, thus increasing the load on IPNI and SPs.