### PR TITLE
fix: check Graphsync retrievals too

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -43,7 +43,8 @@ export default class Spark {
     const { indexerResult, provider } = await queryTheIndex(retrieval.cid)
     stats.indexerResult = indexerResult
 
-    if (indexerResult !== 'OK' && indexerResult !== 'HTTP_NOT_ADVERTISED') return
+    const providerFound = indexerResult === 'OK' || indexerResult === 'HTTP_NOT_ADVERTISED'
+    if (!providerFound) return
 
     stats.protocol = provider.protocol
     stats.providerAddress = provider.address

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -43,7 +43,7 @@ export default class Spark {
     const { indexerResult, provider } = await queryTheIndex(retrieval.cid)
     stats.indexerResult = indexerResult
 
-    if (indexerResult !== 'OK') return
+    if (indexerResult !== 'OK' && indexerResult !== 'HTTP_NOT_ADVERTISED') return
 
     stats.protocol = provider.protocol
     stats.providerAddress = provider.address


### PR DESCRIPTION
When the storage provider does not advertise HTTP retrieval, but advertises Grapsync retrievals, then let's perform the retrieval check.

This was my original intention when I implemented IPNI querying.

I discovered the problem by accident while working on #55. Unfortunately, there is no easy way how to write a reliable automated test for this, as we would need a CID that's guaranteed to have only Graphsync advertised to IPNI.

FWIW, we want to move to testing HTTP retrievals only and drop support for Graphsync (see https://github.com/filecoin-station/spark/issues/46). However, since we are not there yet, I feel this bug is still worth fixing.

Here is a script I used to verify the fix manually. Please not you need to include changes from #55 to be able to reproduce the problem.

```js
import Spark from './lib/spark.js'

const spark = new Spark()
const stats = {
  byteLength: 0
}

await spark.executeRetrievalCheck({
  cid: 'bafybeidkqbga5lsv4b7uhp2lyvuqsx7topvawtsn7ypej3lz44abs55wfu',
  minerId: 'f02055540'
}, stats)

console.log('\nSTATS\n', stats)
```