### PR TITLE
Feat: Get station_id from Zinnia env and add to measurements submission 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: curl -L https://github.com/filecoin-station/zinnia/releases/download/v0.16.0/zinnia-linux-x64.tar.gz | tar -xz
+      - run: curl -L https://github.com/filecoin-station/zinnia/releases/download/v0.18.1/zinnia-linux-x64.tar.gz | tar -xz
       - uses: actions/setup-node@v3
       - run: npx standard
       - run: ./zinnia run test.js

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -170,7 +170,8 @@ export default class Spark {
       zinniaVersion: Zinnia.versions.zinnia,
       ...task,
       ...stats,
-      participantAddress: Zinnia.walletAddress
+      participantAddress: Zinnia.walletAddress,
+      stationId: Zinnia.stationId
     }
     console.log('%o', payload)
     const res = await this.#fetch('https://api.filspark.com/measurements', {

--- a/test/spark.js
+++ b/test/spark.js
@@ -131,7 +131,8 @@ test('submitRetrieval', async () => {
           sparkVersion: SPARK_VERSION,
           zinniaVersion: Zinnia.versions.zinnia,
           cid: 'bafytest',
-          participantAddress: Zinnia.walletAddress
+          participantAddress: Zinnia.walletAddress,
+          stationId: Zinnia.stationId
         }),
         headers: { 'Content-Type': 'application/json' }
       }


### PR DESCRIPTION
- Get station_id from Zinnia env and add to measurements submission
- Bump Zinnia version for GH workflow

This PR supersedes and closes #59. GitHub did not run CI checks there.

Links:
- https://github.com/filecoin-station/roadmap/issues/96
