### PR TITLE
feat: log error activity when no `stationId`

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+/* global Zinnia */
+
 import Spark from './lib/spark.js'
 
 if (!Zinnia.stationId) {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,8 @@
 import Spark from './lib/spark.js'
 
+if (!Zinnia.stationId) {
+  Zinnia.activity.error('Your Station version is outdated. Please upgrade it as soon as possible.')
+}
+
 const spark = new Spark()
 await spark.run()


### PR DESCRIPTION
Example output:

```
❯ zinnia run main.js
[11:14:28.293 ERROR] Your Station version is outdated. Please upgrade it as soon as possible.
Getting current SPARK round details...
[11:14:28.399  INFO] SPARK started reporting retrievals
```

I am not convinced this is needed or a good idea, let me know what do you think.

/cc @juliangruber @PatrickNercessian

Links:
- filecoin-station/roadmap#96
