### PR TITLE
fix: handle legacy dev wallet provided by zinnia

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -165,12 +165,17 @@ export default class Spark {
 
   async submitMeasurement (task, stats) {
     console.log('Submitting measurement...')
+    let participantAddress = Zinnia.walletAddress
+    if (participantAddress === 't1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za') {
+      participantAddress = '0x000000000000000000000000000000000000dEaD'
+    }
+
     const payload = {
       sparkVersion: SPARK_VERSION,
       zinniaVersion: Zinnia.versions.zinnia,
       ...task,
       ...stats,
-      participantAddress: Zinnia.walletAddress,
+      participantAddress,
       stationId: Zinnia.stationId
     }
     console.log('%o', payload)

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -165,6 +165,8 @@ export default class Spark {
 
   async submitMeasurement (task, stats) {
     console.log('Submitting measurement...')
+    // Workaround until there is a new zinnia binary with the following fix:
+    // https://github.com/filecoin-station/zinnia/pull/538
     let participantAddress = Zinnia.walletAddress
     if (participantAddress === 't1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za') {
       participantAddress = '0x000000000000000000000000000000000000dEaD'

--- a/test/spark.js
+++ b/test/spark.js
@@ -131,7 +131,7 @@ test('submitRetrieval', async () => {
           sparkVersion: SPARK_VERSION,
           zinniaVersion: Zinnia.versions.zinnia,
           cid: 'bafytest',
-          participantAddress: Zinnia.walletAddress,
+          participantAddress: '0x000000000000000000000000000000000000dEaD',
           stationId: Zinnia.stationId
         }),
         headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
This is a temporary workaround until we figure out how to build the fixed zinnia version (see https://github.com/filecoin-station/zinnia/pull/538)

This should fix the CI builds and allow us to publish new versions from this repo.
