### PR TITLE
ci: upgrade deprecated GH actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: curl -L https://github.com/filecoin-station/zinnia/releases/download/v0.18.3/zinnia-linux-x64.tar.gz | tar -xz
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - run: npx standard
       - run: ./zinnia run test.js


### PR DESCRIPTION
- actions/checkout@v4
- actions/setup-node@v4

<img width="1244" alt="Screenshot 2024-05-13 at 17 26 03" src="https://github.com/filecoin-station/spark/assets/1140553/cd964aab-bb12-4fb3-aca9-56685ac05673">
