### PR TITLE
fix: improve logs

### DIFF
--- a/lib/ipni-client.js
+++ b/lib/ipni-client.js
@@ -16,7 +16,7 @@ export async function queryTheIndex (cid, providerId) {
   try {
     const res = await fetch(url)
     if (!res.ok) {
-      console.error('IPNI query failed, HTTP response: %s %s', res.status, await res.text())
+      console.error('IPNI query failed, HTTP response: %s %s', res.status, (await res.text()).trimEnd())
       return { indexerResult: `ERROR_${res.status}` }
     }
 

--- a/lib/miner-info.js
+++ b/lib/miner-info.js
@@ -36,7 +36,7 @@ async function rpc (method, ...params) {
   const res = await fetch(req)
 
   if (!res.ok) {
-    throw new Error(`JSON RPC failed with ${res.code}: ${await res.text()}`)
+    throw new Error(`JSON RPC failed with ${res.code}: ${(await res.text()).trimEnd()}`)
   }
 
   const body = await res.json()

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -153,14 +153,13 @@ export default class Spark {
         }
       } else {
         console.error('Retrieval failed with status code %s: %s',
-          res.status, await res.text())
+          res.status, (await res.text()).trimEnd())
       }
     } finally {
       clearTimeout(timeout)
     }
 
     stats.endAt = new Date()
-    console.log(stats)
   }
 
   async submitMeasurement (task, stats) {
@@ -226,6 +225,7 @@ export default class Spark {
       if (delay > 0) {
         console.log('Sleeping for %s seconds before starting the next task...', Math.round(delay / 1000))
         await sleep(delay)
+        console.log() // add an empty line to visually delimit logs from different tasks
       }
     }
   }
@@ -247,7 +247,7 @@ async function assertOkResponse (res, errorMsg) {
   try {
     body = await res.text()
   } catch {}
-  const err = new Error(`${errorMsg ?? 'Fetch failed'} (${res.status}): ${body}`)
+  const err = new Error(`${errorMsg ?? 'Fetch failed'} (${res.status}): ${body.trimEnd()}`)
   err.statusCode = res.status
   err.serverMessage = body
   throw err

--- a/manual-check.js
+++ b/manual-check.js
@@ -13,3 +13,4 @@ const minerId = 'f010479'
 const spark = new Spark()
 const stats = {}
 await spark.executeRetrievalCheck({ cid, minerId }, stats)
+console.log('Measurement: %o', stats)


### PR DESCRIPTION
Example output before my change:

```
Retrieval failed with status code 502: no candidates found

{
  timeout: false,
  startAt: 2024-05-31T07:30:43.389Z,
  // etc.
  protocol: "graphsync",
  providerAddress: "/ip4/118.212.68.22/tcp/24501/p2p/12D3KooWJJEL214g7yMFMFaE6aPRaQTLVVCNFjWeiBLUCTzP98tp"
}
Submitting measurement...
{
  sparkVersion: "1.11.4",
  zinniaVersion: "0.19.1",
  cid: "bafykbzacechhbxnsn5dw6lx7phcfvkjc6kqsuuwl4bnynexewb5y3vtcw2fvw",
  minerId: "f02894875",
  timeout: false,
  startAt: 2024-05-31T07:30:43.389Z,
  // etc.
  providerAddress: "/ip4/118.212.68.22/tcp/24501/p2p/12D3KooWJJEL214g7yMFMFaE6aPRaQTLVVCNFjWeiBLUCTzP98tp",
  participantAddress: "0x000000000000000000000000000000000000dEaD",
  stationId: "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
}
```

This commit removes the first log which was printed when `fetch()` was able to get some HTTP response frome the server.

It is also removing the trailing newline from HTTP error response bodies before we print them to the console.

Finally, it adds an empty line between tasks, to visually delimit logs belonging to different tasks.
