### PR TITLE
fix: reject non-semver strings in release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,11 @@ git diff --quiet HEAD || (echo "please revert the uncommited changes"; exit 1)
 
 SPARK_VERSION="${1?Missing required argument: semver}"
 
+(echo "$SPARK_VERSION" | grep -Eq  '^\d+\.\d+\.\d+$') || {
+  echo Invalid version string \'$SPARK_VERSION\'. Must be MAJOR.MINOR.PATCH
+  exit 1
+}
+
 sed -i '' -e "s/SPARK_VERSION = .*/SPARK_VERSION = '$SPARK_VERSION'/" lib/constants.js
 git add lib/constants.js
 git commit -m v"$SPARK_VERSION"


### PR DESCRIPTION
Fail when the next version is specified as a non-semver string, e.g. "minor" or "patch".
