### PR TITLE
fix: record `startAt` just before the retrieval

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -100,6 +100,8 @@ export default class Spark {
     const carBuffer = new ArrayBuffer(0, { maxByteLength: MAX_CAR_SIZE })
     const carBytes = new Uint8Array(carBuffer)
 
+    stats.startAt = new Date()
+
     try {
       const url = getRetrievalUrl(protocol, address, cid)
       console.log(`Fetching: ${url}`)
@@ -232,7 +234,7 @@ export default class Spark {
 export function newStats () {
   return {
     timeout: false,
-    startAt: new Date(),
+    startAt: null,
     firstByteAt: null,
     endAt: null,
     carTooLarge: false,


### PR DESCRIPTION
Exclude miner-info RPC API call and IPNI lookup from the timing information.

I realised this is a quickest & easiest way how to fix the TTFB values we are
already recording & visualising in Grafana.

Previous discussion that I decided to ignore:
- https://github.com/filecoin-station/spark/issues/54
