### PR TITLE
 fix: retry `Filecoin.StateMinerInfo` requests

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,6 +7,8 @@
 export { encodeHex } from 'https://deno.land/std@0.203.0/encoding/hex.ts'
 export { decodeBase64 } from 'https://deno.land/std@0.203.0/encoding/base64.ts'
 export { decode as decodeVarint } from 'https://deno.land/x/varint@v2.0.0/varint.ts'
+export { retry } from 'https://deno.land/std@0.203.0/async/retry.ts';
+
 
 // Deno Bundle does not support npm dependencies, we have to load them via CDN
 export { CarBlockIterator } from 'https://cdn.skypack.dev/@ipld/car@5.3.2/?dts'

--- a/lib/miner-info.js
+++ b/lib/miner-info.js
@@ -1,3 +1,4 @@
+import { retry } from '../vendor/deno-deps.js'
 import { RPC_URL, RPC_AUTH } from './constants.js'
 
 /**
@@ -6,7 +7,14 @@ import { RPC_URL, RPC_AUTH } from './constants.js'
  */
 export async function getMinerPeerId (minerId) {
   try {
-    const res = await rpc('Filecoin.StateMinerInfo', minerId, null)
+    const res = await retry(() => rpc('Filecoin.StateMinerInfo', minerId, null), {
+      // The maximum amount of attempts until failure.
+      maxAttempts: 5,
+      // The initial and minimum amount of milliseconds between attempts.
+      minTimeout: 5_000,
+      // How much to backoff after each retry.
+      multiplier: 1.5
+    })
     return res.PeerId
   } catch (err) {
     err.message = `Cannot obtain miner info for ${minerId}: ${err.message}`

--- a/lib/miner-info.js
+++ b/lib/miner-info.js
@@ -3,13 +3,15 @@ import { RPC_URL, RPC_AUTH } from './constants.js'
 
 /**
  * @param {string} minerId A miner actor id, e.g. `f0142637`
+ * @param {object} options
+ * @param {number} [options.maxAttempts]
  * @returns {Promise<string>} Miner's PeerId, e.g. `12D3KooWMsPmAA65yHAHgbxgh7CPkEctJHZMeM3rAvoW8CZKxtpG`
  */
-export async function getMinerPeerId (minerId) {
+export async function getMinerPeerId (minerId, { maxAttempts = 5 } = {}) {
   try {
     const res = await retry(() => rpc('Filecoin.StateMinerInfo', minerId, null), {
       // The maximum amount of attempts until failure.
-      maxAttempts: 5,
+      maxAttempts,
       // The initial and minimum amount of milliseconds between attempts.
       minTimeout: 5_000,
       // How much to backoff after each retry.
@@ -17,6 +19,10 @@ export async function getMinerPeerId (minerId) {
     })
     return res.PeerId
   } catch (err) {
+    if (err.name === 'RetryError' && err.cause) {
+      // eslint-disable-next-line no-ex-assign
+      err = err.cause
+    }
     err.message = `Cannot obtain miner info for ${minerId}: ${err.message}`
     throw err
   }

--- a/test/miner-info.test.js
+++ b/test/miner-info.test.js
@@ -11,7 +11,7 @@ test('get peer id of a known miner', async () => {
 
 test('get peer id of a miner that does not exist', async () => {
   try {
-    const result = await getMinerPeerId('f010')
+    const result = await getMinerPeerId('f010', { maxAttempts: 1 })
     throw new AssertionError(
       `Expected "getMinerPeerId()" to fail, but it resolved with "${result}" instead.`
     )


### PR DESCRIPTION
- **deps: add `retry` from Deno stdlib**
- **fix: retry `Filecoin.StateMinerInfo` requests**

I noticed that sometimes my Station Desktop will go offline. The module logs contain the following messages:

```
[2024-09-23T12:43:03Z INFO  module:spark/main] Calling Filecoin JSON-RPC to get PeerId of miner f02085652
{"type":"activity:error","module":"spark/main","message":"SPARK failed reporting retrieval"}
[2024-09-23T12:43:04Z ERROR module:spark/main] Error: Cannot obtain miner info for f02085652: error sending request for url (https://api.node.glif.io/): connection closed before message completed
        at async mainFetch (ext:deno_fetch/26_fetch.js:277:12)
        at async fetch (ext:deno_fetch/26_fetch.js:504:7)
        at async rpc (file:///Users/bajtos/Library/Caches/app.filstation.desktop/sources/spark/lib/miner-info.js:36:15)
        at async Spark.getMinerPeerId (file:///Users/bajtos/Library/Caches/app.filstation.desktop/sources/spark/lib/miner-info.js:9:17)
        at async Spark.executeRetrievalCheck (file:///Users/bajtos/Library/Caches/app.filstation.desktop/sources/spark/lib/spark.js:50:22)
        at async Spark.nextRetrieval (file:///Users/bajtos/Library/Caches/app.filstation.desktop/sources/spark/lib/spark.js:197:5)
        at async Spark.run (file:///Users/bajtos/Library/Caches/app.filstation.desktop/sources/spark/lib/spark.js:208:9)
        at async file:///Users/bajtos/Library/Caches/app.filstation.desktop/sources/spark/main.js:4:1
[2024-09-23T12:43:04Z INFO  module:spark/main] Sleeping for 75 seconds before starting the next task...
```

In other words, when the RPC API fails, Spark waits more than a minute until it starts another check. I _think_ that next check will pick the next task from the list, meaning that Spark effectively skips a task when this error happens.

In this pull request, I am wrapping the RPC request in a retry logic.
